### PR TITLE
Fix incorrect repository URLs in installation scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Victoria can be installed on macOS, Linux, and Windows.
 The recommended way to install Victoria on macOS and Linux is with the `install.sh` script. This will install the Victoria fleet as command-line tools on your system.
 
 ```bash
-curl -sL https://raw.githubusercontent.com/elcanotek/victoria/main/install.sh | bash
+curl -sL https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/install.sh | bash
 ```
 
 This script will:
@@ -39,7 +39,7 @@ On Windows, you can install Victoria using the `install.ps1` PowerShell script.
 
 3.  **Download and Run the Installer:** Run the following command to download and execute the installation script.
     ```powershell
-    iwr https://raw.githubusercontent.com/elcanotek/victoria/main/install.ps1 -useb | iex
+    iwr https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/install.ps1 -useb | iex
     ```
 
 This script will:
@@ -82,7 +82,7 @@ If you wish to remove Victoria from your system, you can use the provided uninst
 Run the `uninstall.sh` script from the repository directory, or download and run it directly:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/elcanotek/victoria/main/uninstall.sh | bash
+curl -sL https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/uninstall.sh | bash
 ```
 
 This script will:
@@ -94,7 +94,7 @@ This script will:
 Run the `uninstall.ps1` script from the repository directory, or download and run it directly in PowerShell:
 
 ```powershell
-iwr https://raw.githubusercontent.com/elcanotek/victoria/main/uninstall.ps1 -useb | iex
+iwr https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/uninstall.ps1 -useb | iex
 ```
 
 This script will:
@@ -116,8 +116,8 @@ If you want to contribute to Victoria, you can set up a development environment 
 
 1.  **Clone the Repository:**
     ```bash
-    git clone https://github.com/elcanotek/victoria.git
-    cd victoria
+    git clone https://github.com/ElcanoTek/victoria-fleet.git
+    cd victoria-fleet
     ```
 
 2.  **Create a Virtual Environment:**

--- a/install.ps1
+++ b/install.ps1
@@ -6,17 +6,17 @@
 # To run this script, use one of the following commands in PowerShell:
 #
 # # Install stable version (default)
-# irm https://raw.githubusercontent.com/elcanotek/victoria/main/install.ps1 | iex
+# irm https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/install.ps1 | iex
 #
 # # Install latest version
-# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/elcanotek/victoria/main/install.ps1))) "latest"
+# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/install.ps1))) "latest"
 #
 # # Install specific version
-# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/elcanotek/victoria/main/install.ps1))) "v1.2.3"
+# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/ElcanoTek/victoria-fleet/main/install.ps1))) "v1.2.3"
 #
 
 # --- Configuration ---
-$RepoUrl = "https://github.com/elcanotek/victoria.git"
+$RepoUrl = "https://github.com/ElcanoTek/victoria-fleet.git"
 $DefaultBranch = "main" # 'stable' version
 $InstallDir = "$env:USERPROFILE\.victoria"
 $VenvDir = "$InstallDir\venv"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 INSTALL_DIR="$HOME/.victoria"
 VENV_DIR="$INSTALL_DIR/venv"
 BIN_DIR="/usr/local/bin"
-REPO_URL="https://github.com/elcanotek/victoria.git"
+REPO_URL="https://github.com/ElcanoTek/victoria-fleet.git"
 DEFAULT_BRANCH="main" # 'stable' version
 
 # --- Helper Functions ---


### PR DESCRIPTION
## Problem
The installation scripts and documentation contain incorrect repository URLs that point to 'elcanotek/victoria' instead of 'ElcanoTek/victoria-fleet'. This causes the installation process to fail because the repository doesn't exist.

## Changes Made
- **install.sh**: Updated REPO_URL from 'elcanotek/victoria' to 'ElcanoTek/victoria-fleet'
- **install.ps1**: Updated $RepoUrl from 'elcanotek/victoria' to 'ElcanoTek/victoria-fleet'
- **README.md**: Fixed all GitHub URLs to point to the correct repository
- **README.md**: Fixed directory name in developer setup instructions (victoria -> victoria-fleet)
- **install.ps1**: Updated PowerShell script comments with correct URLs

## Testing
- ✅ Tested the installation process with the fixed install.sh script
- ✅ Installation completed successfully with dummy API key
- ✅ All Victoria commands (victoria-configurator, victoria-terminal, victoria-browser) work correctly
- ✅ Configuration process completed successfully

## Impact
This fix resolves the critical installation failure and ensures users can successfully install Victoria using the provided scripts.