### PR TITLE
Fix uninstall script to remove configuration directory

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,6 +3,7 @@ set -e
 
 # --- Configuration ---
 INSTALL_DIR="$HOME/.victoria"
+CONFIG_DIR="$HOME/Victoria"
 BIN_DIR="/usr/local/bin"
 WRAPPERS=("victoria-configurator" "victoria-terminal" "victoria-browser")
 
@@ -47,6 +48,15 @@ if [ -d "$INSTALL_DIR" ]; then
     print_success "Victoria installation directory removed."
 else
     print_info "Installation directory $INSTALL_DIR does not exist, skipping."
+fi
+
+# 3. Remove configuration directory
+if [ -d "$CONFIG_DIR" ]; then
+    print_info "Removing configuration directory at $CONFIG_DIR..."
+    rm -rf "$CONFIG_DIR"
+    print_success "Victoria configuration directory removed."
+else
+    print_info "Configuration directory $CONFIG_DIR does not exist, skipping."
 fi
 
 print_success "Victoria has been uninstalled successfully!"


### PR DESCRIPTION
## Problem
The uninstall script was not cleaning up the ~/Victoria directory that contains configuration files like .env and .first_run_complete. This meant that after uninstalling Victoria, user configuration files were left behind on the system.

## Solution
Added cleanup of the configuration directory to the uninstall script to ensure complete removal of Victoria files during uninstallation.

## Changes
- Added CONFIG_DIR variable pointing to ~/Victoria
- Added logic to remove the configuration directory after removing the installation directory
- Added appropriate info and success messages for the cleanup process

## Testing
- Tested the installation process with dummy API key
- Verified that configuration files are created in ~/Victoria
- Tested the fixed uninstall script and confirmed it removes both ~/.victoria and ~/Victoria directories completely